### PR TITLE
add v2b-subgroup whiteboard tag

### DIFF
--- a/vuln2bugs.json.inc
+++ b/vuln2bugs.json.inc
@@ -19,8 +19,11 @@
 	//Operator is a pretty special one. If it's not set only operator:none with the given autogroup will be selected.
 	//If it IS set, then BOTH operator:none and operator:<what-you-set> will be selected by the given autogroup.
 	//Operator names match the autogroup names when present
-	// If includeservices is in a team configuration and set to true, extended service information will be
-	// incorporated with the bug if it is available
+	//If includeservices is in a team configuration and set to true, extended service information will be
+	//incorporated with the bug if it is available
+	//If subgroup is set this value will be used in the v2b-subgroup whiteboard tag, if unset default will be
+	//used. If the same bugzilla component is used for more than one bug, the subgroup should be set to different values
+	//so vuln2bugs can distinguish between them.
 	"teamsetup": {
 		"myteam": {
 			"operator": "IT",

--- a/vuln2bugs.py
+++ b/vuln2bugs.py
@@ -108,7 +108,8 @@ def bug_create(config, teamcfg, title, body, attachments):
     bug.description = body
     today = toUTC(datetime.now())
     sla = today + timedelta(days=7)
-    bug.whiteboard = 'autoentry v2b-autoclose v2b-autoremind v2b-duedate={}'.format(sla.strftime('%Y-%m-%d'))
+    bug.whiteboard = 'autoentry v2b-autoclose v2b-autoremind v2b-duedate={} v2b-subgroup={}'.format(sla.strftime('%Y-%m-%d'),
+        teamcfg['subgroup'])
     bug.priority = teamcfg['priority']
     bug.severity = teamcfg['severity']
     bug = b.post_bug(bug)
@@ -527,7 +528,8 @@ def find_latest_open_bug(config, team):
 
     terms = [{'product': teamcfg['product']}, {'component': teamcfg['component']},
             {'creator': config['bugzilla']['creator']}, {'whiteboard': 'autoentry'}, {'resolution': ''},
-            {'status': 'NEW'}, {'status': 'ASSIGNED'}, {'status': 'REOPENED'}, {'status': 'UNCONFIRMED'}]
+            {'status': 'NEW'}, {'status': 'ASSIGNED'}, {'status': 'REOPENED'}, {'status': 'UNCONFIRMED'},
+            {'whiteboard': 'v2b-subgroup={}'.format(teamcfg['subgroup'])}]
     bugs = b.search_bugs(terms)['bugs']
     #Newest only
     try:
@@ -671,7 +673,9 @@ def main():
 
     # Note that the pyes library returns DotDicts which are addressable like mydict['hi'] an mydict.hi
     for team in teams:
-        debug('Processing team: {} using filter {}'.format(team, teams[team]['filter']))
+        if 'subgroup' not in teams[team]:
+            teams[team]['subgroup'] = 'default'
+        debug('Processing team: {} (subgroup {}) using filter {}'.format(team, teams[team]['subgroup'], teams[team]['filter']))
         teamvulns = TeamVulns(config, team)
         processor = VulnProcessor(config, teamvulns, team)
         debug('{} assets affected by vulnerabilities with the selected filter.'.format(len(teamvulns.assets)))


### PR DESCRIPTION
This allows differentiation between configurations if more than one bug
lives in the same component. If a subgroup is not set on a team
configuration, just use "default".
