### PR TITLE
fix cvss score filtering, add label filtering

### DIFF
--- a/vuln2bugs.json.inc
+++ b/vuln2bugs.json.inc
@@ -49,9 +49,12 @@
 		// Optional:
 		// mincvss: Vulnerabilities must have at least specified CVSS value, defaults
 		//          to 0 if not specified.
+		// risklabels: The risk label in the vulnerability must be set to a value in
+		//             risklabels to be escalated
 		"default-filter": {
 			"_time_period": 24,
 			"mincvss": 5.0,
+			"risklabels": ["high", "critical"],
 			"sourcename": "scanapi"
 		},
 		"all-vulnerabilities": {

--- a/vuln2bugs.py
+++ b/vuln2bugs.py
@@ -168,6 +168,14 @@ class VulnProcessor():
         pkg_affected = dict()
         total_affected_hosts = 0
 
+        try:
+            mincvss = float(self.config['es'][teamcfg['filter']]['mincvss'])
+        except KeyError:
+            mincvss = None
+        try:
+            risklabels = self.config['es'][teamcfg['filter']]['risklabels']
+        except KeyError:
+            risklabels = None
         # Unroll all vulns
         for assetkey in sorted(assets.keys()):
             assetdata = assets[assetkey]
@@ -176,6 +184,15 @@ class VulnProcessor():
             titles = list()
             cves = list()
             titlelinkmap = dict()
+
+            # Apply any CVSS filters
+            if mincvss != None:
+                assetdata['vulnerabilities'] = [x for x in assetdata['vulnerabilities'] \
+                        if 'cvss' in x and x['cvss'] != '' and float(x['cvss']) >= mincvss]
+            # Apply any label filters
+            if risklabels != None:
+                assetdata['vulnerabilities'] = [x for x in assetdata['vulnerabilities'] \
+                        if 'risk' in x and x['risk'] in risklabels]
 
             if len(assetdata['vulnerabilities']) == 0:
                 continue


### PR DESCRIPTION
CVSS score filtering was present in the configuration file but was not
working. This change allows filtering based on cvss score, and also
based on the "risk" label present in the vulnerability documents.